### PR TITLE
Move networking-bigswitch to openstack namespace

### DIFF
--- a/rdo.yml
+++ b/rdo.yml
@@ -364,7 +364,7 @@ packages:
   - ihrachys@redhat.com
 - project: networking-bigswitch
   name: python-networking-bigswitch
-  upstream: git://git.openstack.org/stackforge/%(project)s
+  upstream: git://git.openstack.org/openstack/%(project)s
   source-branch: stable/kilo
   master-distgit: git://github.com/openstack-packages/%(name)s
   distro-branch: rpm-kilo


### PR DESCRIPTION
This was done for the official rdoinfo, but not for the Kilo one.
