### PR TITLE
Move python-keystoneclient to rpm-kilo

### DIFF
--- a/rdo.yml
+++ b/rdo.yml
@@ -199,6 +199,7 @@ packages:
 # The openstack clients
 - project: keystoneclient
   conf: client
+  distro-branch: rpm-kilo
 - project: glanceclient
   conf: client
 - project: novaclient


### PR DESCRIPTION
Required since https://review.gerrithub.io/251928, there is no
python-keystoneauth1 in kilo.
